### PR TITLE
bugfix: revert terminal state after setting to raw in interactive mode

### DIFF
--- a/script/execute.go
+++ b/script/execute.go
@@ -86,6 +86,7 @@ func Execute(pkScript []byte, witness [][]byte, interactive bool) error {
 		defer t.Close()
 
 		term.RawMode(t)
+		defer t.Restore()
 	}
 
 	currentStep := 0


### PR DESCRIPTION
During interactive mode and without restore the terminal is left in raw mode which is clunky for usage.